### PR TITLE
fix(api): コーヒー記録の追加処理を修正

### DIFF
--- a/src/app/api/coffee/route.ts
+++ b/src/app/api/coffee/route.ts
@@ -7,17 +7,9 @@ export async function POST(request: NextRequest) {
   try {
     const { date, cups, time } = await request.json()
 
-    const record = await prisma.coffeeRecord.upsert({
-      where: {
-	userId_date: {
-	  date: parseISO(date), userId: 'default-user',
-	}
-      },
-      update: {
-        cups: { increment: cups },
-        time: parseISO(time),
-      },
-      create: {
+    const record = await prisma.coffeeRecord.create({
+      data: {
+        userId: 'default-user',
         date: parseISO(date),
         cups,
         timestamp: parseISO(time),


### PR DESCRIPTION
`upsert` を使用していたAPIエンドポイントを `create` を使用するように修正しました。 これにより、データベーススキーマとの不整合によって発生していたサーバーエラーが解消され、コーヒー記録が正しく追加されるようになります。

注意: プロジェクトには別の箇所にビルドエラーが存在するため、この修正単体での完全な動作検証は完了していません。具体的には `src/app/api/coffee/[data]/route.ts` の `DELETE` エンドポイントに型定義の問題があります。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Changed the behavior for adding coffee records so that each submission now always creates a new record, rather than updating existing entries for the same user and date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->